### PR TITLE
Update taming/data/utils.py

### DIFF
--- a/taming/data/utils.py
+++ b/taming/data/utils.py
@@ -8,10 +8,11 @@ from pathlib import Path
 import numpy as np
 import torch
 from taming.data.helper_types import Annotation
-from torch._six import string_classes
 from torch.utils.data._utils.collate import np_str_obj_array_pattern, default_collate_err_msg_format
 from tqdm import tqdm
 
+# alternative to deprecated torch._six.string_classes
+string_classes = (str,)
 
 def unpack(path):
     if path.endswith("tar.gz"):


### PR DESCRIPTION
As `torch._six` is no longer available in recent PyTorch versions, updating it to use alternate representation of `string_classes` with `str` type.