### PR TITLE
bugfix(pip install): fix taming package imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 setup(
     name='taming-transformers',
     version='1.0.0+pt-2.0',
     description='Taming Transformers for High-Resolution Image Synthesis',
-    packages=find_packages(),
+    packages=find_namespace_packages(include=["taming*"]),
     install_requires=[
         'torch',
         'numpy',


### PR DESCRIPTION
`pip install git+https://github.com/swghosh/taming-transformers.git` has no effect upon installation.


```
>>> from taming.models.vqgan import GumbelVQ
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'taming'
>>> 
```